### PR TITLE
Settings Fix - Now capable of persisting settings

### DIFF
--- a/ProjectSettings/AudioManager.asset.meta
+++ b/ProjectSettings/AudioManager.asset.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: db6ee100f5a757a439e2f55d9d1d74ec
-timeCreated: 1496882309
-licenseType: Pro
-NativeFormatImporter:
-  mainObjectFileID: -1
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/ClusterInputManager.asset.meta
+++ b/ProjectSettings/ClusterInputManager.asset.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 8765ea5084e5c5f46a0216a95b9285c1
-timeCreated: 1496882309
-licenseType: Pro
-NativeFormatImporter:
-  mainObjectFileID: -1
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/DynamicsManager.asset.meta
+++ b/ProjectSettings/DynamicsManager.asset.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 358af9ae9ead5d846a0d5d9298ce247f
-timeCreated: 1496882308
-licenseType: Pro
-NativeFormatImporter:
-  mainObjectFileID: -1
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/EditorBuildSettings.asset.meta
+++ b/ProjectSettings/EditorBuildSettings.asset.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 334479175bb05a649b8f5114e85f1864
-timeCreated: 1496882308
-licenseType: Pro
-NativeFormatImporter:
-  mainObjectFileID: -1
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/EditorSettings.asset.meta
+++ b/ProjectSettings/EditorSettings.asset.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 665b62dc45d2ca94296853715946055f
-timeCreated: 1496882309
-licenseType: Pro
-NativeFormatImporter:
-  mainObjectFileID: -1
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/GraphicsSettings.asset.meta
+++ b/ProjectSettings/GraphicsSettings.asset.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: f54d15edc50a78341ad7ca4c98955013
-timeCreated: 1496882309
-licenseType: Pro
-NativeFormatImporter:
-  mainObjectFileID: -1
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/InputManager.asset.meta
+++ b/ProjectSettings/InputManager.asset.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 25438f8aba5ea124199d8b0f63942e63
-timeCreated: 1496882308
-licenseType: Pro
-NativeFormatImporter:
-  mainObjectFileID: -1
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/NavMeshAreas.asset.meta
+++ b/ProjectSettings/NavMeshAreas.asset.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 7515e43dd4611a049888d288018b4472
-timeCreated: 1496882309
-licenseType: Pro
-NativeFormatImporter:
-  mainObjectFileID: -1
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/NetworkManager.asset.meta
+++ b/ProjectSettings/NetworkManager.asset.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 0b127547cbe53a642a96401654dd3c18
-timeCreated: 1496882308
-licenseType: Pro
-NativeFormatImporter:
-  mainObjectFileID: -1
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/Physics2DSettings.asset.meta
+++ b/ProjectSettings/Physics2DSettings.asset.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: cd91a66dc06dcac4cb76ffb862248f54
-timeCreated: 1496882309
-licenseType: Pro
-NativeFormatImporter:
-  mainObjectFileID: -1
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset.meta
+++ b/ProjectSettings/ProjectSettings.asset.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 3ef12ceb26b87404cba8dc15630c7730
-timeCreated: 1496882308
-licenseType: Pro
-NativeFormatImporter:
-  mainObjectFileID: -1
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/ProjectVersion.txt.meta
+++ b/ProjectSettings/ProjectVersion.txt.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 7ce957983e5b9ca4fbb82843fe385c1d
-timeCreated: 1496882308
-licenseType: Pro
-TextScriptImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/QualitySettings.asset.meta
+++ b/ProjectSettings/QualitySettings.asset.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 118d695d1bdd7894f907cf0a8c0a851a
-timeCreated: 1496882308
-licenseType: Pro
-NativeFormatImporter:
-  mainObjectFileID: -1
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset.meta
+++ b/ProjectSettings/TagManager.asset.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: b6879103301e0534ba1b9a36d560da7a
-timeCreated: 1496882309
-licenseType: Pro
-NativeFormatImporter:
-  mainObjectFileID: -1
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/TimeManager.asset.meta
+++ b/ProjectSettings/TimeManager.asset.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: d18f1879ca996ec4d86d4338fd06e232
-timeCreated: 1496882309
-licenseType: Pro
-NativeFormatImporter:
-  mainObjectFileID: -1
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/UnityConnectSettings.asset.meta
+++ b/ProjectSettings/UnityConnectSettings.asset.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: e9f943b5049a5d54bba897f87ff1b6e4
-timeCreated: 1496882309
-licenseType: Pro
-NativeFormatImporter:
-  mainObjectFileID: -1
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
The .meta files were causing Unity to be able to persist settings when saving the project or exiting Unity

Fixes #1 